### PR TITLE
fix: Calculating closest grid line when calendar is taller than viewport

### DIFF
--- a/src/plugins/copy-event-plugin.ts
+++ b/src/plugins/copy-event-plugin.ts
@@ -309,7 +309,7 @@ export class CopyEventPlugin {
     const hour = Array.from(document.querySelectorAll(".sx__week-grid__hour"))
       .reduce((closest, el) => {
         const rect = (el as HTMLElement).getBoundingClientRect();
-        const distance = Math.abs(y - rect.top);
+        const distance = Math.abs(y - (rect.top + window.scrollY));
 
         return distance < closest.distance
           ? { element: el as HTMLElement, distance }


### PR DESCRIPTION
# Fix paste target calculation when calendar overflows viewport

When page that the calendar is on, is taller than viewport (overflows from the top), target time for paste is calculated incorrectly.

## Reproducing the issue

Follow the steps below or see attached video.
1. Zoom calendar or resize window so that calendar is taller than viewport (so that top of the page is outside of the viewport)
2. Copy an event (drag and drop)
3. The event is pasted 

https://github.com/user-attachments/assets/33e7360d-e0e5-4c52-a5b6-92249a12c29b

## Cause and fix

`getDateTimeFromPosition` is called with MouseEvent's `pageX` and `pageY` which are relative to the whole document. However, the position for time grid lines is obtained with `getBoundingClientRect` that provides position relative to the top-left of the viewport. Hence, closest distance calculation ends up being incorrect when top of the document is outside viewport.

Fix was to adjust grid line position based on scrollY as suggested in [`getBoundingClientRect's` documentation](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect):
> If you need the bounding rectangle relative to the top-left corner of the document, just add the current scrolling position to the top and left properties (these can be obtained using [window.scrollY](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY) and [window.scrollX](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollX)) to get a bounding rectangle which is independent from the current scrolling position.